### PR TITLE
Laravel 5.8 defaults user to bigIncrements()

### DIFF
--- a/src/resources/database/migrations/2017_11_27_131855_create_orders_table.php
+++ b/src/resources/database/migrations/2017_11_27_131855_create_orders_table.php
@@ -11,7 +11,7 @@ class CreateOrdersTable extends Migration
             $table->increments('id');
             $table->string('number', 32);
             $table->string('status', 32);
-            $table->integer('user_id')->unsigned()->nullable();
+            $table->bigInteger('user_id')->unsigned()->nullable();
             $table->integer('billpayer_id')->unsigned()->nullable();
             $table->integer('shipping_address_id')->unsigned()->nullable();
             $table->text('notes')->nullable();


### PR DESCRIPTION
New 5.8 Laravel defaults conflict with the default Vanilo install. https://laraveldaily.com/be-careful-laravel-5-8-added-bigincrements-as-defaults/