### PR TITLE
Fixed interface called instead of proxy error

### DIFF
--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -103,7 +103,7 @@ class Order extends Model implements OrderContract
 
     public function scopeOpen(Builder $query)
     {
-        return $query->whereIn('status', OrderStatus::getOpenStatuses());
+        return $query->whereIn('status', OrderStatusProxy::getOpenStatuses());
     }
 
     /**


### PR DESCRIPTION
The interface was called in the query scope instead of the proxy. Fixed it.